### PR TITLE
seperate dev/prod configs

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -6,7 +6,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const assetPath = './assets/main/index.js';
 const assetPathCritical = './assets/main/index-critical';
 
-const webpackDev = {
+const webpackConfig = {
     target: 'web',
     stats: true,
     entry: {
@@ -100,11 +100,6 @@ const webpackDev = {
     },
 
     plugins: [
-        new webpack.DefinePlugin({
-            'process.env': {
-                'NODE_ENV': JSON.stringify('production')
-            }
-        }),
         new webpack.ProvidePlugin({
           // Automtically detect jQuery and $ as free var in modules
           // and inject the jquery library
@@ -121,4 +116,4 @@ const webpackDev = {
     ]
 };
 
-module.exports = webpackDev;
+module.exports = webpackConfig;

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -6,7 +6,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const assetPath = './assets/main/index.js';
 const assetPathCritical = './assets/main/index-critical';
 
-const webpackProd = {
+const webpackConfig = {
     target: 'web',
     stats: true,
     entry: {
@@ -100,11 +100,6 @@ const webpackProd = {
     },
 
     plugins: [
-        new webpack.DefinePlugin({
-            'process.env': {
-                'NODE_ENV': JSON.stringify('production')
-            }
-        }),
         new webpack.ProvidePlugin({
           // Automtically detect jQuery and $ as free var in modules
           // and inject the jquery library
@@ -129,4 +124,4 @@ const webpackProd = {
     ]
 };
 
-module.exports = webpackProd;
+module.exports = webpackConfig;


### PR DESCRIPTION
I separate dev and prod configs and choose webpack "the manual way", so that we can define two fully independent configuration files.
[more about webpack the manual way](https://webpack.js.org/guides/production/#the-manual-way)

Closes #2 